### PR TITLE
Fix: Incorrect use of `typing.Union`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ${{ matrix.name || matrix.python }}
+    name: ci ${{ matrix.python }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,8 +39,8 @@ jobs:
         sudo apt install libmaxminddb0 libmaxminddb-dev
         python -m pip install --upgrade pip
         pip install tox
-    - name: test
+    - name: Test
       run: tox -e py
-    - name: lint
+    - name: Lint
       if: matrix.python-version == '3.12'
       run: tox -e lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: ci ${{ matrix.python }}
+    name: ci ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,32 +15,34 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Go environment
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
-    - name: Setup Java JDK
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 22
-        cache: maven
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-        check-latest: true
-    - name: Install dependencies
-      run: |
-        sudo apt install libmaxminddb0 libmaxminddb-dev
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Test
-      run: tox -e py
-    - name: Lint
-      if: matrix.python-version == '3.12'
-      run: tox -e lint
+      - uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: tests/clients/go/go.sum
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 22
+          cache: maven
+          cache-dependency-path: tests/clients/java/pom.xml
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          check-latest: true
+      - name: Install dependencies
+        run: |
+          sudo apt install libmaxminddb0 libmaxminddb-dev
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Test
+        run: tox -e py
+      - name: Lint
+        if: matrix.python-version == '3.12'
+        run: tox -e lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
-name: Python application
+name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "ci/*" ]
   pull_request:
     branches: [ "master" ]
 
@@ -13,10 +10,12 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
+  test:
+    name: ${{ matrix.name || matrix.python }}
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup Go environment
@@ -29,20 +28,19 @@ jobs:
         distribution: temurin
         java-version: 22
         cache: maven
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-        cache: pip
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+        check-latest: true
     - name: Install dependencies
       run: |
         sudo apt install libmaxminddb0 libmaxminddb-dev
         python -m pip install --upgrade pip
-        pip install ".[test,dev]"
-    - name: Check with ruff
-      run: |
-        ruff check
-        ruff format --check
-    - name: Test with pytest
-      run: |
-        pytest
+        pip install tox
+    - name: test
+      run: tox -e py
+    - name: lint
+      if: matrix.python-version == '3.12'
+      run: tox -e lint

--- a/mmdb_writer.py
+++ b/mmdb_writer.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import logging
 import math

--- a/mmdb_writer.py
+++ b/mmdb_writer.py
@@ -23,7 +23,7 @@ class MmdbF32(MmdbBaseType):
 
 
 class MmdbF64(MmdbBaseType):
-    def __init__(self, value: Union[float | Decimal]):
+    def __init__(self, value: Union[float, Decimal]):
         super().__init__(value)
 
 
@@ -145,14 +145,14 @@ IntType = Union[
         "uint64",
         "uint128",
         "int32",
-    ]
-    | MmdbU16
-    | MmdbU32
-    | MmdbU64
-    | MmdbU128
-    | MmdbI32
+    ],
+    MmdbU16,
+    MmdbU32,
+    MmdbU64,
+    MmdbU128,
+    MmdbI32,
 ]
-FloatType = Union[Literal["f32", "f64", "float32", "float64"] | MmdbF32 | MmdbF64]
+FloatType = Union[Literal["f32", "f64", "float32", "float64"], MmdbF32, MmdbF64]
 
 
 class Encoder:
@@ -547,7 +547,7 @@ class MMDBWriter:
         ip_version=4,
         database_type="GeoIP",
         languages: List[str] = None,
-        description: Union[Dict[str, str] | str] = "GeoIP db",
+        description: Union[Dict[str, str], str] = "GeoIP db",
         ipv4_compatible=False,
         int_type: IntType = "auto",
         float_type: FloatType = "f64",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mmdb_writer"
 description = "Make `mmdb` format ip library file which can be read by maxmind official language reader"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 keywords = ["mmdb", "maxmind"]
 authors = [{ name = "VimT", email = "me@vimt.me" } ]
 classifiers = [
@@ -16,8 +16,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+    py3{13,12,11,10,9,8}
+    lint
+skip_missing_interpreters = true
+
+[testenv]
+description = run unit tests
+extras = test
+commands = pytest
+
+[testenv:lint]
+extras = dev
+commands =
+    ruff check --no-fix
+    ruff format --check


### PR DESCRIPTION
## Which issue does this PR close?

Related #4 

## Rationale for this change
can't run in `python3.6`

## What changes are included in this PR?
1. fix bug
`typing.Union` should be `Union[float, Decimal]` instead of `Union[float | Decimal]`

2. ci
use tox to run ci with different Python versions

## Are these changes tested?
Yes

## Are there any user-facing changes?
No
