### PR TITLE
fix: compatibility with libmaxminddb v1.13.x stricter validation

### DIFF
--- a/mmdb_writer.py
+++ b/mmdb_writer.py
@@ -686,6 +686,6 @@ class MMDBWriter:
             "languages": self.languages,
             "binary_format_major_version": self.binary_format_major_version,
             "binary_format_minor_version": self.binary_format_minor_version,
-            "build_epoch": int(time.time()),
             "description": self.description,
+            "build_epoch": int(time.time()),
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,6 +68,33 @@ class TestBuild(unittest.TestCase):
             self.assertEqual(record2, m.get("1.10.10.1"), mode)
             m.close()
 
+    def test_empty_description(self):
+        """Regression test for https://github.com/vimt/MaxMind-DB-Writer-python/issues/16
+        libmaxminddb v1.13.x added stricter validation that rejects files where an
+        empty map/array is the last element in the metadata section.
+        """
+        writer = MMDBWriter()
+        writer.insert_network(
+            IPSet(["1.1.0.0/24", "1.1.1.0/24"]),
+            {"country": "COUNTRY", "isp": "ISP"},
+        )
+        writer.to_db_file(self.filename)
+        for mode in (maxminddb.MODE_MMAP_EXT, maxminddb.MODE_MMAP, maxminddb.MODE_FILE):
+            m = maxminddb.open_database(self.filename, mode=mode)
+            self.assertEqual({"country": "COUNTRY", "isp": "ISP"}, m.get("1.1.0.0"), mode)
+            self.assertEqual({"country": "COUNTRY", "isp": "ISP"}, m.get("1.1.1.0"), mode)
+            m.close()
+
+    def test_empty_languages(self):
+        """Ensure empty languages array doesn't cause issues with strict validation."""
+        writer = MMDBWriter(languages=[])
+        writer.insert_network(IPSet(["10.0.0.0/8"]), {"value": "test"})
+        writer.to_db_file(self.filename)
+        for mode in (maxminddb.MODE_MMAP_EXT, maxminddb.MODE_MMAP, maxminddb.MODE_FILE):
+            m = maxminddb.open_database(self.filename, mode=mode)
+            self.assertEqual({"value": "test"}, m.get("10.0.0.1"), mode)
+            m.close()
+
     def test_int_type(self):
         value_range_map = {}
         value_range_map.update(


### PR DESCRIPTION
## Summary

- libmaxminddb v1.13.0 added validation in `get_entry_data_list()` that checks `offset >= data_section_size` for MAP/ARRAY types during metadata parsing (`MMDB_open` → `read_metadata` → `populate_description_metadata`)
- When the metadata section ends with an empty map (e.g. empty `description` when no languages are specified), `offset_to_next` equals `metadata_section_size`, triggering this `>=` check and causing `MMDB_open` to fail with `MMDB_INVALID_DATA_ERROR`
- Fix: reorder metadata fields so `build_epoch` (a scalar UINT64, not subject to the MAP/ARRAY size validation) is always the last entry

## Root Cause

In `_build_meta()`, `description` was the last key. When `description` is `{}` (empty dict, default when no languages provided), the encoded metadata ends with `\xe0` (MAP with 0 entries). The byte after this MAP header has `offset_to_next == metadata_section_size`, which fails the new `offset >= data_section_size` check added in [libmaxminddb v1.13.0](https://github.com/maxmind/libmaxminddb/releases/tag/1.13.0).

## Test plan

- [x] Added `test_empty_description` regression test (exact reproduction from #16)
- [x] Added `test_empty_languages` test for empty languages array
- [x] All existing tests pass
- [x] Verified with `MODE_MMAP_EXT` (C extension / libmaxminddb 1.13.2), `MODE_MMAP`, and `MODE_FILE`

Fixes #16

Made with [Cursor](https://cursor.com)